### PR TITLE
[FIX] 메인 영역 css값 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,12 +27,14 @@ onMounted(() => {
 
 <template>
   <div>
-    <div class=".container-fluid">
+    <div class="container-fluid">
       <Topbar class="topbar" />
     </div>
     <Header />
-    <div class="app-container">
-      <RouterView />
+    <div class="container-sm">
+      <div class="app-container">
+        <RouterView />
+      </div>
     </div>
     <div class="">
       <Footer class="footer" />
@@ -41,11 +43,11 @@ onMounted(() => {
 </template>
 
 <style>
-.app-container {
+/* .app-container {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-}
+} */
 .topbar {
   position: sticky;
   top: 0;

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import './style.css'
 import './reset.css'
+import './style.css'
+
 import App from './App.vue'
 import router from "./util/router/router"
 

--- a/src/style.css
+++ b/src/style.css
@@ -35,9 +35,9 @@ a:hover {
 .app-container {
   margin: 0;
   padding: 0;
+  padding-top: 30px;
   place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  min-height: 75vh;
   width: 100%; /* 뷰포트의 전체 너비를 차지 */
   box-sizing: border-box; /* 패딩과 보더를 width 계산에 포함 */
 }


### PR DESCRIPTION
- 컨테이너에 넣어서 좌우 여백 조정
- footer 살짝 보이게 세로 비율 조정(min-height: 75vh)
- app-container에 padding-top 30px
- main.js의 css 파일 import 순서 변경(초기화 우선 적용)