### PR TITLE
[REFACTOR] steps 부분 수정, 결제/참여내역 부분 라우팅경로 수정, 결제등록 수정중

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ const checkScroll = () => {
 onMounted(() => {
     // Check if payment is successful and redirect if needed
     if (paymentStore.isPaymentSuccessful) {
-        router.push('/purchase/step30/:id');
+        router.push('/purchase/complete/:id');
         paymentStore.resetPaymentStatus();
     }
     window.addEventListener('scroll', checkScroll)

--- a/src/components/participation/Participation.vue
+++ b/src/components/participation/Participation.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="participation-container">
-        <h2 class="title">참여내역</h2>
+        <h2 class="title">펀딩 참여내역</h2>
 
         <!-- 필터 드롭다운 -->
         <div class="filter-dropdown">
@@ -23,7 +23,7 @@
                 <p class="byline">by {{ item.author }}</p>
                 <div class="cancel-link">
                     <button @click="showCancelModal = true" class="change-button">결제 예약 취소</button>
-                    <router-link :to="`/participation/${item.id}`" class="details-link">상세보기 &gt;</router-link>
+                    <router-link :to="`/mywadiz/info/participation/${item.id}`" class="details-link">상세보기 &gt;</router-link>
                 </div>
             </div>
         </div>

--- a/src/components/participation/ParticipationDetail.vue
+++ b/src/components/participation/ParticipationDetail.vue
@@ -151,7 +151,7 @@
                 리워드 발송에 대해 발생한 이슈는 프로젝트 상세 페이지 - 환불・정책 탭에 명시한 정책을 따릅니다.
             </p>
             <button class="back-button">
-                <router-link to="/participation">목록으로 돌아가기</router-link>
+                <router-link to="/mywadiz/info/participation">목록으로 돌아가기</router-link>
             </button>
         </div>
     </div>
@@ -185,7 +185,7 @@ function cancelReservation() {
     // 결제 예약 취소 로직 추가
     console.log("결제 예약 취소됨");
     showCancelModal.value = false; // 모달 닫기
-    router.push('/participation');   // '/participate'로 라우팅
+    router.push('/mywadiz/info/participation');   // '/participate'로 라우팅
 }
 </script>
 

--- a/src/components/payment/ChooseReward.vue
+++ b/src/components/payment/ChooseReward.vue
@@ -42,7 +42,7 @@
         </div>
     </div>
 
-    <RouterLink :to="`/purchase/step20/${id}`">
+    <RouterLink :to="`/purchase/reserve/${id}`">
         <button type="button" class="btn btn-primary w-100 my-1" @click="saveToStore">다음 단계</button>
     </RouterLink>
 
@@ -66,7 +66,7 @@ const selectedRewards = ref([]);
 const donationAmount = ref(0);
 const route = useRoute();
 
-const steps = ref(["리워드 선택", "결제 예약", "소문내기"]);
+const steps = ref(["리워드 선택", "결제 화면", "결제 완료"]);
 
 // Pinia 스토어 인스턴스 (Setup Store 형태로 사용)
 const purchaseStore = usePurchaseStore();

--- a/src/components/payment/CompletePayment.vue
+++ b/src/components/payment/CompletePayment.vue
@@ -1,8 +1,19 @@
 <template>
+    
+
     <div class="top-bar">
         <RouterLink :to="`/funding/detail/${id}`">
             < 스토리로 돌아가기 </RouterLink>
                 <h6>Looper 공항에서 여권을 찾느라 가방을 뒤집는 당신을 위해</h6>
+    </div>
+
+    <div class="progress-steps my-5">
+        <div v-for="(step, index) in steps" :key="index" class="step-container">
+            <div :class="['step-circle', { 'step-completed': index === 2, 'step-pending': index !== 2 }]">
+                {{ step }}
+            </div>
+            <div v-if="index < steps.length - 1" class="dashed-line"></div>
+        </div>
     </div>
     <div class="complete-payment-container">
         <!-- 참여 완료 메시지 -->
@@ -15,14 +26,14 @@
                 <p class="fw-bold">나만 알고 있기 아까운 프로젝트라면?</p>
                 <p>친구에게 소개하고 | 포인트를 받아보세요</p>
             </div>
-            <RouterLink to="/participation">
+            <RouterLink to="/mywadiz/info/participation">
                 <button class="next-button">다음</button>
             </RouterLink>
-            
+
         </div>
 
         <!-- 주식회사 루피 정보 -->
-        <div class="company-info d-flex justify-content-between">
+        <!-- <div class="company-info d-flex justify-content-between">
             <div class="text-start d-flex">
                 <img src="#">
                 <div>
@@ -31,19 +42,19 @@
                 
             </div>
             <button class="follow-button">팔로우</button>
-        </div>
+        </div> -->
 
         <!-- 놀랄 수 없는 이벤트 섹션 -->
-        <div class="event-section my-4">
+        <!-- <div class="event-section my-4">
             <h5>놓칠 수 없는 이벤트</h5>
             <div class="event-image">
                 <img src="../../assets/event-placeholder.png" />
             </div>
             <p>나다운 성장, 원 포인트 레벨업!</p>
-        </div>
+        </div> -->
 
         <!-- 추천 프로젝트 섹션 -->
-        <div class="project-recommendation">
+        <!-- <div class="project-recommendation">
             <h5>내 취향에 맞는 프로젝트</h5>
             <div class="project-grid">
                 <div v-for="n in 4" :key="n" class="project-card">
@@ -51,10 +62,10 @@
                     <p>프로젝트 제목 {{ n }}</p>
                 </div>
             </div>
-        </div>
+        </div> -->
 
         <!-- 관심 갈 만한 프로젝트 섹션 -->
-        <div class="project-interest">
+        <!-- <div class="project-interest">
             <h5>관심 갈 만한 프로젝트</h5>
             <div class="project-grid">
                 <div v-for="n in 4" :key="n" class="project-card">
@@ -62,12 +73,12 @@
                     <p>프로젝트 제목 {{ n }}</p>
                 </div>
             </div>
-        </div>
+        </div> -->
     </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { usePaymentStore } from '../../util/store/paymentStore';
 
@@ -75,6 +86,8 @@ defineProps(['id']); // id를 명시적으로 props로 정의
 
 const router = useRouter();
 const paymentStore = usePaymentStore();
+
+const steps = ref(["리워드 선택", "결제 화면", "결제 완료"]);
 
 onMounted(() => {
     // 결제 성공 상태 확인
@@ -86,6 +99,48 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.progress-steps {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: normal;
+    /* 일반적인 줄바꿈 허용 */
+    word-break: keep-all;
+    /* 단어 단위로 줄바꿈 */
+}
+
+.step-container {
+    display: flex;
+    align-items: center;
+}
+
+.step-circle {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: white;
+}
+
+.step-completed {
+    background-color: #4db4d7;
+    /* Example color for completed step */
+}
+
+.step-pending {
+    background-color: #e9ecef;
+}
+
+.dashed-line {
+    border-top: 2px dashed #000000;
+    width: 80px;
+    margin: 0 10px;
+    /* 필요시 약간의 여백을 추가 */
+}
+
 .top-bar {
     display: flex;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);

--- a/src/util/router/payment-router.js
+++ b/src/util/router/payment-router.js
@@ -13,19 +13,19 @@ import ParticipationDetail from "../../components/participation/ParticipationDet
 
 export default [
     {
-        path: "/purchase/step10/:id",
+        path: "/purchase/choose/:id",
         name: "ChooseReward",
         component: ChooseReward,
         props: true,
     },
     {
-        path: "/purchase/step20/:id",
+        path: "/purchase/reserve/:id",
         name: "ReservePayment",
         component: ReservePayment,
         props: true,
     },
     {
-        path: "/purchase/step30/:id",
+        path: "/purchase/complete/:id",
         name: "CompletePayment",
         component: CompletePayment,
         props: true,
@@ -75,12 +75,12 @@ export default [
         ]
     },
     {
-        path: '/participation',
+        path: '/mywadiz/info/participation',
         name: 'Participation',
         component: Participation,
     },
     {
-        path: '/participation/:id',
+        path: '/mywadiz/info/participation/:id',
         name: 'ParticipationDetail',
         component: ParticipationDetail,
     },

--- a/src/util/store/authStore.js
+++ b/src/util/store/authStore.js
@@ -3,11 +3,12 @@ import { ref } from 'vue'; // ref 추가
 
 export const useAuthStore = defineStore('auth', () => {
     // 상태 변수: JWT 토큰
-    const jwtToken = ref(null);
+    const jwtToken = ref(localStorage.getItem('jwtToken'));
 
     // 토큰 설정 메소드
     function setJwtToken(token) {
         jwtToken.value = token;
+        localStorage.setItem('jwtToken', token);
     }
 
     // 토큰 가져오기 메소드


### PR DESCRIPTION
steps 부분의 경우 기존의 결제예약과 소문내기를 각각 결제화면과 결제완료로 수정

결제 라우팅 부분 수정 - /purchase/stepXX을 각각  /purchase/choose,  /purchase/reserve,  /purchase/complete로 수정

참여 라우팅 부분 수정(participation) - 기존 경로 앞에 /mywadiz/info/를 추가함

결제 등록의 경우 결제 내역을 데이터베이스에 등록하는 것을 완료하였으나, 성공/실패 여부에 따라 paymentStatus가 변경되는 부분을 구현중